### PR TITLE
Fix a error about loss `categorical_crossentropy`.

### DIFF
--- a/imageai/Prediction/Custom/__init__.py
+++ b/imageai/Prediction/Custom/__init__.py
@@ -133,7 +133,7 @@ class ModelTraining:
 
 
 
-    def trainModel(self, num_objects, num_experiments=200, enhance_data=False, batch_size = 32, initial_learning_rate=1e-3, show_network_summary=False, training_image_size = 224):
+    def trainModel(self, num_objects, num_experiments=200, enhance_data=False, batch_size = 32, initial_learning_rate=1e-3, show_network_summary=False, training_image_size = 224, option_loss='mean_squared_error', option_optimizer='sgd'):
 
         """
                  'trainModel()' function starts the actual training. It accepts the following values:
@@ -149,6 +149,8 @@ class ModelTraining:
                                                     Itis set to False by default
                  - training_image_size(optional) , this value is used to define the image size on which the model will be trained. The
                                             value is 224 by default and is kept at a minimum of 100.
+                 - option_loss(optional) , see https://keras.io/losses/
+                 - option_optimizer(optional) , see https://keras.io/losses/
 
                  *
 
@@ -159,6 +161,8 @@ class ModelTraining:
                 :param initial_learning_rate:
                 :param show_network_summary:
                 :param training_image_size:
+                :param option_loss:
+                :param option_optimizer:
                 :return:
                 """
         self.__num_epochs = num_experiments
@@ -242,6 +246,12 @@ class ModelTraining:
         num_train = len(train_generator.filenames)
         num_test = len(test_generator.filenames)
         print("Number of experiments (Epochs) : ", self.__num_epochs)
+
+        #
+        print("Loss : ", option_loss)
+        print("Optimizer : ", option_optimizer)
+        print("See https://keras.io/losses/")
+        model.compile(loss=option_loss, optimizer=option_optimizer)
 
         #
         model.fit_generator(train_generator, steps_per_epoch=int(num_train / batch_size), epochs=self.__num_epochs,


### PR DESCRIPTION
I don't quite understand this situation. It seems that it is caused by the new version of keras. I made some modifications according to the documentation.
Looks like can fix this problem, see https://keras.io/losses/ :
===================================================
Traceback (most recent call last):
  File "train.py", line 5, in <module>
    model_trainer.trainModel(num_objects=4, num_experiments=100, enhance_data=True, batch_size=32, show_network_summary=True)
  File "C:\ProgramData\Anaconda3\lib\site-packages\imageai\Prediction\Custom\__init__.py", line 249, in trainModel
    validation_steps=int(num_test / batch_size), callbacks=[checkpoint, lr_scheduler])
  File "C:\ProgramData\Anaconda3\lib\site-packages\tensorflow\python\keras\engine\training.py", line 1426, in fit_generator
    initial_epoch=initial_epoch)
  File "C:\ProgramData\Anaconda3\lib\site-packages\tensorflow\python\keras\engine\training_generator.py", line 191, in model_iteration
    batch_outs = batch_function(*batch_data)
  File "C:\ProgramData\Anaconda3\lib\site-packages\tensorflow\python\keras\engine\training.py", line 1175, in train_on_batch
    x, y, sample_weight=sample_weight, class_weight=class_weight)
  File "C:\ProgramData\Anaconda3\lib\site-packages\tensorflow\python\keras\engine\training.py", line 2440, in _standardize_user_data
    y, self._feed_loss_fns, feed_output_shapes)
  File "C:\ProgramData\Anaconda3\lib\site-packages\tensorflow\python\keras\engine\training_utils.py", line 493, in check_loss_and_target_compatibility
    y.shape) + ' while using as loss `categorical_crossentropy`. '
ValueError: You are passing a target array of shape (32, 1) while using as loss `categorical_crossentropy`. `categorical_crossentropy` expects targets to be binary matrices (1s and 0s) of shape (samples, classes). If your targets are integer classes, you can convert them to the expected format via:
```
from keras.utils import to_categorical
y_binary = to_categorical(y_int)
```

Alternatively, you can use the loss function `sparse_categorical_crossentropy` instead, which does expect integer targets.
===================================================
This is my first Pull request, and Python is not what I am good at, I hope I am doing it right.