### PR TITLE
quick fix on #302: paddle filenames

### DIFF
--- a/imageai/Detection/Custom/__init__.py
+++ b/imageai/Detection/Custom/__init__.py
@@ -508,7 +508,7 @@ class DetectionModelTrainer:
 
         checkpoint = CustomModelCheckpoint(
             model_to_save=model_to_save,
-            filepath=saved_weights_name + 'ex-{epoch:03d}--loss-{loss:8.3f}.h5',
+            filepath=saved_weights_name + 'ex-{epoch:03d}--loss-{loss:08.3f}.h5',
             monitor='loss',
             verbose=0,
             save_best_only=True,


### PR DESCRIPTION
small fix on #302  to paddle filenames with 0 instead of empty spaces, as [pointed out](htts://github.com/OlafenwaMoses/ImageAI/pull/302#pullrequestreview-278781391) by @auphofBSF 