### PR TITLE
Make object detection capable of using in multiple thread

### DIFF
--- a/imageai/Detection/__init__.py
+++ b/imageai/Detection/__init__.py
@@ -337,7 +337,13 @@ class ObjectDetection:
                     image, scale = resize_image(image, min_side=self.__input_image_min, max_side=self.__input_image_max)
 
                     model = self.__model_collection[0]
-                    _, _, detections = model.predict_on_batch(np.expand_dims(image, axis=0))
+
+                    if thread_safe == True:
+                        with self.sess.graph.as_default():
+                            _, _, detections = model.predict_on_batch(np.expand_dims(image, axis=0))
+                    else:
+                        _, _, detections = model.predict_on_batch(np.expand_dims(image, axis=0))
+
                     predicted_numbers = np.argmax(detections[0, :, 4:], axis=1)
                     scores = detections[0, np.arange(detections.shape[1]), 4 + predicted_numbers]
 
@@ -436,7 +442,7 @@ class ObjectDetection:
 
                     model = self.__model_collection[0]
 
-                    if thread_safe:
+                    if thread_safe == True:
                         with self.sess.graph.as_default():
                             out_boxes, out_scores, out_classes = self.sess.run(
                                 [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
@@ -700,7 +706,13 @@ class ObjectDetection:
                     image, scale = resize_image(image, min_side=self.__input_image_min, max_side=self.__input_image_max)
 
                     model = self.__model_collection[0]
-                    _, _, detections = model.predict_on_batch(np.expand_dims(image, axis=0))
+
+                    if thread_safe == True:
+                        with self.sess.graph.as_default():
+                            _, _, detections = model.predict_on_batch(np.expand_dims(image, axis=0))
+                    else:
+                        _, _, detections = model.predict_on_batch(np.expand_dims(image, axis=0))
+
                     predicted_numbers = np.argmax(detections[0, :, 4:], axis=1)
                     scores = detections[0, np.arange(detections.shape[1]), 4 + predicted_numbers]
 
@@ -803,7 +815,7 @@ class ObjectDetection:
 
                     model = self.__model_collection[0]
 
-                    if thread_safe:
+                    if thread_safe == True:
                         with self.sess.graph.as_default():
                             out_boxes, out_scores, out_classes = self.sess.run(
                                 [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],

--- a/imageai/Detection/__init__.py
+++ b/imageai/Detection/__init__.py
@@ -245,7 +245,7 @@ class ObjectDetection:
 
     def detectObjectsFromImage(self, input_image="", output_image_path="", input_type="file", output_type="file",
                                extract_detected_objects=False, minimum_percentage_probability=50,
-                               display_percentage_probability=True, display_object_name=True):
+                               display_percentage_probability=True, display_object_name=True, thread_safe=False):
         """
             'detectObjectsFromImage()' function is used to detect objects observable in the given image path:
                     * input_image , which can be a filepath, image numpy array or image file stream
@@ -436,13 +436,23 @@ class ObjectDetection:
 
                     model = self.__model_collection[0]
 
-                    out_boxes, out_scores, out_classes = self.sess.run(
-                        [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
-                        feed_dict={
-                            model.input: image_data,
-                            self.__yolo_input_image_shape: [image.size[1], image.size[0]],
-                            K.learning_phase(): 0
-                        })
+                    if thread_safe:
+                        with self.sess.graph.as_default():
+                            out_boxes, out_scores, out_classes = self.sess.run(
+                                [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
+                                feed_dict={
+                                    model.input: image_data,
+                                    self.__yolo_input_image_shape: [image.size[1], image.size[0]],
+                                    K.learning_phase(): 0
+                                })
+                    else:
+                        out_boxes, out_scores, out_classes = self.sess.run(
+                            [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
+                            feed_dict={
+                                model.input: image_data,
+                                self.__yolo_input_image_shape: [image.size[1], image.size[0]],
+                                K.learning_phase(): 0
+                            })
 
                     min_probability = minimum_percentage_probability / 100
                     counting = 0
@@ -598,7 +608,7 @@ class ObjectDetection:
     def detectCustomObjectsFromImage(self, custom_objects=None, input_image="", output_image_path="", input_type="file",
                                      output_type="file", extract_detected_objects=False,
                                      minimum_percentage_probability=50, display_percentage_probability=True,
-                                     display_object_name=True):
+                                     display_object_name=True, thread_safe=False):
         """
                     'detectCustomObjectsFromImage()' function is used to detect predefined objects observable in the given image path:
                             * custom_objects , an instance of the CustomObject class to filter which objects to detect
@@ -793,13 +803,23 @@ class ObjectDetection:
 
                     model = self.__model_collection[0]
 
-                    out_boxes, out_scores, out_classes = self.sess.run(
-                        [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
-                        feed_dict={
-                            model.input: image_data,
-                            self.__yolo_input_image_shape: [image.size[1], image.size[0]],
-                            K.learning_phase(): 0
-                        })
+                    if thread_safe:
+                        with self.sess.graph.as_default():
+                            out_boxes, out_scores, out_classes = self.sess.run(
+                                [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
+                                feed_dict={
+                                    model.input: image_data,
+                                    self.__yolo_input_image_shape: [image.size[1], image.size[0]],
+                                    K.learning_phase(): 0
+                                })
+                    else:
+                        out_boxes, out_scores, out_classes = self.sess.run(
+                            [self.__yolo_boxes, self.__yolo_scores, self.__yolo_classes],
+                            feed_dict={
+                                model.input: image_data,
+                                self.__yolo_input_image_shape: [image.size[1], image.size[0]],
+                                K.learning_phase(): 0
+                            })
 
                     min_probability = minimum_percentage_probability / 100
                     counting = 0


### PR DESCRIPTION
Normally, when `ObjectDetection` is created and load model in other thread and then is used in another thread, Tensorflow will complain that the tensor is not element of this graph.  

This PR uses [Graph.as_default()](https://www.tensorflow.org/api_docs/python/tf/Graph#as_default) to make the current graph to be the default one (the one that is used while load model).  I added flag `thread_safe` for turning on and of this thread safe behavior to both `detectObjectsFromImage` and `detectCustomObjectsFromImage` methods with default value to false.  

**Related API reference**

- [Session.as_default()](https://www.tensorflow.org/api_docs/python/tf/Session?hl=en#as_default)
- [Session.graph property](https://www.tensorflow.org/api_docs/python/tf/Session?hl=en#graph)
- [Graph.as_default()](https://www.tensorflow.org/api_docs/python/tf/Graph#as_default)

P.S. I don't really know about Tensorflow and its API 😅, please correct me if I misunderstand.