### PR TITLE
Update deprecated parameter

### DIFF
--- a/imageai/Detection/Custom/__init__.py
+++ b/imageai/Detection/Custom/__init__.py
@@ -520,7 +520,7 @@ class DetectionModelTrainer:
             patience=2,
             verbose=0,
             mode='min',
-            epsilon=0.01,
+            min_delta=0.01,
             cooldown=0,
             min_lr=0
         )


### PR DESCRIPTION
The "epsilon" parameter of ReduceLROnPlateau is deprecated and is to be removed in future versions, changed it to "min_delta" instead. This fixes UserWarning that is printed when training models.