### PR TITLE
per_frame_function should use frame_detection_interval too

### DIFF
--- a/imageai/Detection/Custom/__init__.py
+++ b/imageai/Detection/Custom/__init__.py
@@ -1083,12 +1083,13 @@ class CustomVideoObjectDetection:
                     if (save_detected_video == True):
                         output_video.write(detected_frame)
 
-                    if (per_frame_function != None):
-                        if (return_detected_frame == True):
-                            per_frame_function(counting, output_objects_array, output_objects_count,
-                                               detected_frame)
-                        elif (return_detected_frame == False):
-                            per_frame_function(counting, output_objects_array, output_objects_count)
+                    if (counting == 1 or check_frame_interval == 0):
+                        if (per_frame_function != None):
+                            if (return_detected_frame == True):
+                                per_frame_function(counting, output_objects_array, output_objects_count,
+                                                   detected_frame)
+                            elif (return_detected_frame == False):
+                                per_frame_function(counting, output_objects_array, output_objects_count)
 
                     if (per_second_function != None):
                         if (counting != 1 and (counting % frames_per_second) == 0):

--- a/imageai/Detection/__init__.py
+++ b/imageai/Detection/__init__.py
@@ -1304,12 +1304,13 @@ class VideoObjectDetection:
                             if (save_detected_video == True):
                                 output_video.write(detected_copy)
 
-                            if (per_frame_function != None):
-                                if (return_detected_frame == True):
-                                    per_frame_function(counting, output_objects_array, output_objects_count,
-                                                       detected_copy)
-                                elif (return_detected_frame == False):
-                                    per_frame_function(counting, output_objects_array, output_objects_count)
+                            if (counting == 1 or check_frame_interval == 0):
+                                if (per_frame_function != None):
+                                    if (return_detected_frame == True):
+                                        per_frame_function(counting, output_objects_array, output_objects_count,
+                                                           detected_copy)
+                                    elif (return_detected_frame == False):
+                                        per_frame_function(counting, output_objects_array, output_objects_count)
 
                             if (per_second_function != None):
                                 if (counting != 1 and (counting % frames_per_second) == 0):
@@ -1545,13 +1546,14 @@ class VideoObjectDetection:
                             if (save_detected_video == True):
                                 output_video.write(detected_copy)
 
-                            if (per_frame_function != None):
+                            if (counting == 1 or check_frame_interval == 0):
                                 if (per_frame_function != None):
-                                    if (return_detected_frame == True):
-                                        per_frame_function(counting, output_objects_array, output_objects_count,
-                                                           detected_copy)
-                                    elif (return_detected_frame == False):
-                                        per_frame_function(counting, output_objects_array, output_objects_count)
+                                    if (per_frame_function != None):
+                                        if (return_detected_frame == True):
+                                            per_frame_function(counting, output_objects_array, output_objects_count,
+                                                               detected_copy)
+                                        elif (return_detected_frame == False):
+                                            per_frame_function(counting, output_objects_array, output_objects_count)
 
                             if (per_second_function != None):
                                 if (counting != 1 and (counting % frames_per_second) == 0):
@@ -1965,12 +1967,13 @@ class VideoObjectDetection:
                             if (save_detected_video == True):
                                 output_video.write(detected_copy)
 
-                            if (per_frame_function != None):
-                                if (return_detected_frame == True):
-                                    per_frame_function(counting, output_objects_array, output_objects_count,
-                                                       detected_copy)
-                                elif (return_detected_frame == False):
-                                    per_frame_function(counting, output_objects_array, output_objects_count)
+                            if (counting == 1 or check_frame_interval == 0):
+                                if (per_frame_function != None):
+                                    if (return_detected_frame == True):
+                                        per_frame_function(counting, output_objects_array, output_objects_count,
+                                                           detected_copy)
+                                    elif (return_detected_frame == False):
+                                        per_frame_function(counting, output_objects_array, output_objects_count)
 
                             if (per_second_function != None):
                                 if (counting != 1 and (counting % frames_per_second) == 0):
@@ -2210,12 +2213,13 @@ class VideoObjectDetection:
                             if (save_detected_video == True):
                                 output_video.write(detected_copy)
 
-                            if (per_frame_function != None):
-                                if (return_detected_frame == True):
-                                    per_frame_function(counting, output_objects_array, output_objects_count,
-                                                       detected_copy)
-                                elif (return_detected_frame == False):
-                                    per_frame_function(counting, output_objects_array, output_objects_count)
+                            if (counting == 1 or check_frame_interval == 0):
+                                if (per_frame_function != None):
+                                    if (return_detected_frame == True):
+                                        per_frame_function(counting, output_objects_array, output_objects_count,
+                                                           detected_copy)
+                                    elif (return_detected_frame == False):
+                                        per_frame_function(counting, output_objects_array, output_objects_count)
 
                             if (per_second_function != None):
                                 if (counting != 1 and (counting % frames_per_second) == 0):


### PR DESCRIPTION
I usually run detectObjectsFromVideo in this way

detections = detector.detectObjectsFromVideo(input_file_path=os.path.join(execution_path , 'videos/'+videofilename), frames_per_second=25, **frame_detection_interval=12**,  minimum_percentage_probability=50, save_detected_video=False, video_complete_function=forSeconds, **per_frame_function=forFrame**, return_detected_frame=True )

With your source code, the function forFrame fires every frame, even if i set **frame_detection_interval=12**

Applying my commit, the behaviour of the detection and the forFrame function are synchronous.
What do you think?