### PR TITLE
the number in detection_details must be greater than or equal to 0

### DIFF
--- a/imageai/Detection/__init__.py
+++ b/imageai/Detection/__init__.py
@@ -368,6 +368,7 @@ class ObjectDetection:
                         color = label_color(label)
 
                         detection_details = detections[0, index, :4].astype(int)
+                        detection_details = np.maximum(detection_details, 0)
                         draw_box(detected_copy, detection_details, color=color)
 
                         if (display_object_name == True and display_percentage_probability == True):
@@ -743,6 +744,7 @@ class ObjectDetection:
                         color = label_color(label)
 
                         detection_details = detections[0, index, :4].astype(int)
+                        detection_details = np.maximum(detection_details, 0)
                         draw_box(detected_copy, detection_details, color=color)
 
                         if (display_object_name == True and display_percentage_probability == True):


### PR DESCRIPTION
We will get a wrong image when we extract detected_objects if the number in detection_details is less than 0.