### PR TITLE
docs: fix simple typo, tramsfer -> transfer

### DIFF
--- a/imageai/Prediction/Custom/__init__.py
+++ b/imageai/Prediction/Custom/__init__.py
@@ -165,7 +165,7 @@ class ModelTraining:
                  - show_network_summary(optional) , this value is used to show the structure of the network should you desire to see it. It is set to False by default
                  - training_image_size(optional) , this value is used to define the image size on which the model will be trained. The value is 224 by default and is kept at a minimum of 100.
                 - continue_from_model (optional) , this is used to set the path to a model file trained on the same dataset. It is primarily for continuos training from a previously saved model.
-                - transfer_from_model (optional) , this is used to set the path to a model file trained on another dataset. It is primarily used to perform tramsfer learning.
+                - transfer_from_model (optional) , this is used to set the path to a model file trained on another dataset. It is primarily used to perform transfer learning.
                 - transfer_with_full_training (optional) , this is used to set the pre-trained model to be re-trained across all the layers or only at the top layers.
                 - initial_num_objects (required if 'transfer_from_model' is set ), this is used to set the number of objects the model used for transfer learning is trained on. If 'transfer_from_model' is set, this must be set as well.
                 - save_full_model ( optional ), this is used to save the trained models with their network types. Any model saved by this specification can be loaded without specifying the network type.


### PR DESCRIPTION
There is a small typo in imageai/Prediction/Custom/__init__.py.

Should read `transfer` rather than `tramsfer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md